### PR TITLE
fix: 전역 상태 관리 및 라우팅 로직 개선

### DIFF
--- a/apps/shop/src/app/_layouts/ClientLayout.tsx
+++ b/apps/shop/src/app/_layouts/ClientLayout.tsx
@@ -1,18 +1,18 @@
 'use client';
-import { Header } from '@/app/_layouts';
+
+import { Header, Providers } from '@/app/_layouts';
 import Loading from '@/app/loading';
 import { AuthGuard } from '@/features/auth';
 import { ErrorBoundary, GlobalPortal } from '@findyourkicks/shared';
 import Image from 'next/image';
 import { Suspense } from 'react';
 import styles from './ClientLayout.module.scss';
-import { Providers } from './providers';
 
 export function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ErrorBoundary>
-      <Providers>
-        <GlobalPortal.Provider>
+    <GlobalPortal.Provider>
+      <ErrorBoundary>
+        <Providers>
           <Suspense fallback={<Loading />}>
             <AuthGuard>
               <Header />
@@ -20,9 +20,9 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
               <Footer />
             </AuthGuard>
           </Suspense>
-        </GlobalPortal.Provider>
-      </Providers>
-    </ErrorBoundary>
+        </Providers>
+      </ErrorBoundary>
+    </GlobalPortal.Provider>
   );
 }
 

--- a/apps/shop/src/app/_layouts/providers.tsx
+++ b/apps/shop/src/app/_layouts/providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Provider } from 'jotai';
+import { Provider as JotaiProvider } from 'jotai';
 import { type ReactNode, useState } from 'react';
 
 export function Providers({ children }: { children: ReactNode }) {
@@ -17,7 +17,7 @@ export function Providers({ children }: { children: ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Provider>{children}</Provider>
+      <JotaiProvider>{children}</JotaiProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/shop/src/app/layout.tsx
+++ b/apps/shop/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import '@findyourkicks/shared/styles/global.scss';
+
 import type { Metadata } from 'next';
 import { ClientLayout } from './_layouts/ClientLayout';
 

--- a/apps/shop/src/features/auth/components/AuthGuard.tsx
+++ b/apps/shop/src/features/auth/components/AuthGuard.tsx
@@ -4,24 +4,25 @@ import { useUser } from '@/features/user/hooks';
 import { PATH } from '@/shared/constants/path';
 import { isAuthPath } from '@/shared/utils';
 import { createClient } from '@/shared/utils/supabase/client';
-import { usePathname } from 'next/navigation';
-import { redirect } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+const supabase = createClient();
+
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const supabase = createClient();
   const pathname = usePathname();
   const { updateUser } = useUser();
+  const router = useRouter();
 
   useEffect(() => {
     const { data: authListener } = supabase.auth.onAuthStateChange(
       async (event, session) => {
         if (!session?.access_token && isAuthPath(pathname)) {
-          redirect(PATH.login);
+          router.push(PATH.login);
         }
 
         if (session?.access_token && pathname === PATH.login) {
-          redirect('/');
+          router.push('/');
         }
 
         if (event === 'SIGNED_OUT') {
@@ -35,7 +36,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     return () => {
       authListener?.subscription.unsubscribe();
     };
-  }, [supabase, pathname, updateUser]);
+  }, [pathname, router, updateUser]);
 
   return children;
 }

--- a/apps/shop/src/features/user/address/components/AddressForm.tsx
+++ b/apps/shop/src/features/user/address/components/AddressForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAddressForm } from '@/features/user/address';
-import { Button, Modal } from '@findyourkicks/shared/components';
+import { Button, Modal } from '@findyourkicks/shared';
 import styles from './AddressForm.module.scss';
 
 const USER_INPUT_NAME = ['name', 'phone', 'alias'] as const;

--- a/apps/shop/src/features/user/hooks/useUser.ts
+++ b/apps/shop/src/features/user/hooks/useUser.ts
@@ -1,5 +1,6 @@
 import type { User } from '@supabase/supabase-js';
 import { atom, useAtom, useAtomValue } from 'jotai';
+import { useCallback } from 'react';
 
 const userAtom = atom<User | null>(null);
 const userIdAtom = atom((get) => get(userAtom)?.id ?? '');
@@ -10,9 +11,12 @@ export function useUser() {
   const userId = useAtomValue(userIdAtom);
   const isAuthenticated = useAtomValue(isAuthenticatedAtom);
 
-  const updateUser = (user: User | null) => {
-    setUser(user);
-  };
+  const updateUser = useCallback(
+    (user: User | null) => {
+      setUser(user);
+    },
+    [setUser],
+  );
 
   return {
     user,

--- a/apps/shop/src/shared/components/layouts/CardLayout.tsx
+++ b/apps/shop/src/shared/components/layouts/CardLayout.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@findyourkicks/shared/components';
+import { Button } from '@findyourkicks/shared';
 import styles from './CardLayout.module.scss';
 
 export default function CardLayout({

--- a/apps/shop/tsconfig.json
+++ b/apps/shop/tsconfig.json
@@ -16,13 +16,13 @@
     },
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "strict": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 변경 사항

- GlobalPortal.Provider를 최상위로 이동하여 포털 관련 에러 처리 개선
- Jotai Provider 이름을 더 명확하게 변경 (Provider → JotaiProvider)
- redirect를 router.push로 변경하여 클라이언트 사이드 라우팅 개선
- useUser 훅의 updateUser 함수를 useCallback으로 메모이제이션하여 리렌더링 개선