### PR TITLE
ci: main 브랜치 push 트리거 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@
 name: Verify Monorepo Build (CI)
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 워크플로우가 이제 main 브랜치로의 직접 푸시가 아닌, 풀 리퀘스트 이벤트에서만 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->