### PR TITLE
feat(shop): 테스트 계정 로그인 기능 추가

### DIFF
--- a/apps/shop/env.d.ts
+++ b/apps/shop/env.d.ts
@@ -7,5 +7,6 @@ declare namespace NodeJS {
     NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
     TOSS_SECRET_KEY: string;
     SUPABASE_SERVICE_ROLE_KEY: string;
+    TEST_ACCOUNT_PW: string;
   }
 }

--- a/apps/shop/src/app/api/auth/test-account/route.ts
+++ b/apps/shop/src/app/api/auth/test-account/route.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@/shared/utils/supabase/server';
+import { assert } from '@findyourkicks/shared';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: 'test@test.com',
+    password: process.env.TEST_ACCOUNT_PW,
+  });
+
+  assert(!error, error?.message ?? '테스트 계정 로그인 실패');
+
+  return NextResponse.json(data);
+}

--- a/apps/shop/src/features/auth/apis.ts
+++ b/apps/shop/src/features/auth/apis.ts
@@ -1,11 +1,20 @@
+import { AUTH_ENDPOINTS } from '@/shared/constants';
 import { api } from '@/shared/utils/api';
 
 export const signInWithGoogle = async (next = '/') => {
-  return await api.get<string>(`/auth/google?next=${encodeURIComponent(next)}`);
+  return await api.get<string>(
+    `${AUTH_ENDPOINTS.signInWithGoogle}?next=${encodeURIComponent(next)}`,
+  );
 };
 
 export const signInWithKakao = async (next = '/') => {
-  return await api.get<string>(`/auth/kakao?next=${encodeURIComponent(next)}`);
+  return await api.get<string>(
+    `${AUTH_ENDPOINTS.signInWithKakao}?next=${encodeURIComponent(next)}`,
+  );
 };
 
-export const signOutUser = async () => await api.post('/auth/signout');
+export const signInWithTestAccount = async () => {
+  return await api.post(AUTH_ENDPOINTS.signInWithTestAccount);
+};
+
+export const signOutUser = async () => await api.post(AUTH_ENDPOINTS.signOut);

--- a/apps/shop/src/features/auth/components/LoginCardButtons.tsx
+++ b/apps/shop/src/features/auth/components/LoginCardButtons.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { signInWithGoogle, signInWithKakao } from '@/features/auth';
+import {
+  signInWithGoogle,
+  signInWithKakao,
+  useTestAccountMutation,
+} from '@/features/auth';
 import { GoogleLogo, KakaoLogo } from '@/shared/components/icons';
 import { Button } from '@findyourkicks/shared';
 import { useRouter } from 'next/navigation';
 
 export function LoginCardButtons() {
   const router = useRouter();
+  const { mutate: signInWithTestAccount, isPending } = useTestAccountMutation({
+    onSuccess: () => router.push('/'),
+  });
 
   return (
     <>
@@ -25,6 +32,14 @@ export function LoginCardButtons() {
         data-testid="google-btn"
       >
         구글계정으로 로그인
+      </Button>
+      <Button
+        variant="primary"
+        radius
+        onClick={() => signInWithTestAccount()}
+        disabled={isPending}
+      >
+        테스트 계정으로 로그인
       </Button>
     </>
   );

--- a/apps/shop/src/features/auth/hooks/index.ts
+++ b/apps/shop/src/features/auth/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useTestAccountMutation';

--- a/apps/shop/src/features/auth/hooks/useTestAccountMutation.ts
+++ b/apps/shop/src/features/auth/hooks/useTestAccountMutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import { signInWithTestAccount } from '../apis';
+
+export function useTestAccountMutation({
+  onSuccess,
+}: { onSuccess: () => void }) {
+  return useMutation({
+    mutationFn: signInWithTestAccount,
+    onSuccess,
+  });
+}

--- a/apps/shop/src/features/auth/index.ts
+++ b/apps/shop/src/features/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
 export * from './apis';
+export * from './hooks';

--- a/apps/shop/src/features/order/components/OrderHistoryList.tsx
+++ b/apps/shop/src/features/order/components/OrderHistoryList.tsx
@@ -5,12 +5,14 @@ import {
   OrderProduct,
   useOrderPagination,
 } from '@/features/order';
+import { NoData } from '@/shared/components';
 import { PATH } from '@/shared/constants/path';
 import {
   ChevronFirst,
   ChevronLast,
   ChevronLeft,
   ChevronRight,
+  ShoppingBagIcon,
 } from 'lucide-react';
 import { Suspense } from 'react';
 import styles from './OrderHistoryList.module.scss';
@@ -19,11 +21,18 @@ export default function OrderHistoryList() {
   const { orderHistory, handlePageChange } = useOrderPagination();
   const { currentPage, hasNext, orders, lastPage } = orderHistory;
   const pageList = Array.from({ length: lastPage }, (_, index) => index + 1);
+  const isEmpty = orders.length === 0;
 
   return (
     <div>
       <Suspense fallback={<MyOrdersLoading />}>
         <article className={styles.article}>
+          {isEmpty && (
+            <NoData
+              icon={<ShoppingBagIcon width={40} height={40} />}
+              title="주문 내역이 없습니다."
+            />
+          )}
           {orders.map(({ orderDate, orderId, products }) => (
             <OrderListLayout
               key={orderId}
@@ -38,54 +47,58 @@ export default function OrderHistoryList() {
         </article>
       </Suspense>
 
-      <div className={styles.pagination}>
-        <button
-          type="button"
-          onClick={() => handlePageChange(1)}
-          disabled={currentPage === 1}
-          className={currentPage === 1 ? styles.button__disabled : ''}
-        >
-          <ChevronFirst />
-        </button>
-
-        <button
-          type="button"
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage === 1}
-          className={currentPage === 1 ? styles.button__disabled : ''}
-        >
-          <ChevronLeft />
-        </button>
-
-        {pageList.map((pageNumber) => (
+      {!isEmpty && (
+        <div className={styles.pagination}>
           <button
-            key={pageNumber}
             type="button"
-            onClick={() => handlePageChange(pageNumber)}
-            className={currentPage === pageNumber ? styles.button__active : ''}
+            onClick={() => handlePageChange(1)}
+            disabled={currentPage === 1}
+            className={currentPage === 1 ? styles.button__disabled : ''}
           >
-            {pageNumber}
+            <ChevronFirst />
           </button>
-        ))}
 
-        <button
-          type="button"
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={!hasNext}
-          className={currentPage === lastPage ? styles.button__disabled : ''}
-        >
-          <ChevronRight />
-        </button>
+          <button
+            type="button"
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            className={currentPage === 1 ? styles.button__disabled : ''}
+          >
+            <ChevronLeft />
+          </button>
 
-        <button
-          type="button"
-          onClick={() => handlePageChange(lastPage)}
-          disabled={currentPage === lastPage}
-          className={currentPage === lastPage ? styles.button__disabled : ''}
-        >
-          <ChevronLast />
-        </button>
-      </div>
+          {pageList.map((pageNumber) => (
+            <button
+              key={pageNumber}
+              type="button"
+              onClick={() => handlePageChange(pageNumber)}
+              className={
+                currentPage === pageNumber ? styles.button__active : ''
+              }
+            >
+              {pageNumber}
+            </button>
+          ))}
+
+          <button
+            type="button"
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={!hasNext}
+            className={currentPage === lastPage ? styles.button__disabled : ''}
+          >
+            <ChevronRight />
+          </button>
+
+          <button
+            type="button"
+            onClick={() => handlePageChange(lastPage)}
+            disabled={currentPage === lastPage}
+            className={currentPage === lastPage ? styles.button__disabled : ''}
+          >
+            <ChevronLast />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/shop/src/shared/components/NoData.module.scss
+++ b/apps/shop/src/shared/components/NoData.module.scss
@@ -1,7 +1,7 @@
 .section {
   @include flex-center-col;
-  gap: 1rem;
+  gap: 16px;
   width: 100%;
-  height: 15rem;
+  min-height: 360px;
   font-size: $font-sm;
 }

--- a/apps/shop/src/shared/constants/apiEndpoints.ts
+++ b/apps/shop/src/shared/constants/apiEndpoints.ts
@@ -2,6 +2,7 @@ import { path } from '@/shared/utils';
 
 const ROOT_CART = '/cart';
 const ROOT_USER = '/users';
+const ROOT_AUTH = '/auth';
 
 export const ENDPOINTS = {
   cart: ROOT_CART,
@@ -17,4 +18,12 @@ export const USER_ENDPOINTS = {
   user: ROOT_USER,
   addresses: path(ROOT_USER, '/addresses'),
   addressDefault: path(ROOT_USER, '/addresses/default'),
+} as const;
+
+export const AUTH_ENDPOINTS = {
+  auth: ROOT_AUTH,
+  signInWithTestAccount: path(ROOT_AUTH, '/test-account'),
+  signInWithGoogle: path(ROOT_AUTH, '/google'),
+  signInWithKakao: path(ROOT_AUTH, '/kakao'),
+  signOut: path(ROOT_AUTH, '/signout'),
 } as const;

--- a/packages/shared/components/Carousel.tsx
+++ b/packages/shared/components/Carousel.tsx
@@ -42,7 +42,7 @@ export function Carousel({ images, onClose, isOpen }: CarouselProps) {
           >
             {images.map((image) => (
               <SwiperSlide key={image} className={styles.swiperSlide}>
-                <img src={image} alt="carousel" />
+                <img src={image} alt="carousel" loading="lazy" />
               </SwiperSlide>
             ))}
           </Swiper>

--- a/packages/shared/utils/createQueries.ts
+++ b/packages/shared/utils/createQueries.ts
@@ -48,7 +48,5 @@ export function createQueries<
       queryKey: ReturnType<(typeof queryKeyMap)[K]>;
       queryFn: () => ReturnType<ReturnType<T[K]>['queryFn']>;
     };
-  } & {
-    queryKeys: typeof queryKeyMap;
   };
 }


### PR DESCRIPTION
## 변경 사항

- 테스트 계정 로그인 API 엔드포인트 및 mutation hook 추가
- 로그인 페이지에 테스트 계정 로그인 버튼 추가
- 인증 관련 엔드포인트를 중앙화된 상수로 리팩토링
- 주문 내역 페이지 빈데이터 UI 개선 (NoData UI 추가)
- 캐러셀 이미지 lazy loading